### PR TITLE
Dont alter binary datatype columns

### DIFF
--- a/lib/demoji.rb
+++ b/lib/demoji.rb
@@ -30,7 +30,7 @@ module Demoji
 
     def _fix_utf8_attributes
       self.attributes.each do |k, v|
-        next if v.blank? || !v.is_a?(String)
+        next if v.blank? || !v.is_a?(String) || (self.column_for_attribute(k).type == :binary)
         self.send "#{k}=", _fix_chars(v)
       end
     end

--- a/spec/models/test_user_spec.rb
+++ b/spec/models/test_user_spec.rb
@@ -32,6 +32,17 @@ describe TestUser do
     expect(u.reload.name.strip).to eql "Peter Perez"
   end
 
+  it "fixes non-binary columns but leaves binary columns alone" do
+    u = TestUser.new
+    u.name = "Peter Perez\n#{ord_to_str(65554)}"
+    cart = "some binary data #{ord_to_str(65554)}"
+    u.cart = cart
+    expect{ u.save }.to_not raise_error
+    expect(u).to be_persisted
+    expect(u.reload.name.strip).to eql "Peter Perez"
+    expect(u.reload.cart).to eql "some binary data \xF0\x90\x80\x92"
+  end
+
   it "doesn't mess up with valid language specific chars" do
     u = TestUser.new
     u.name = "#{ord_to_str(252)}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,10 @@ RSpec.configure do |config|
     ActiveRecord::Base.establish_connection db_config
 
     ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `test_users`")
-    ActiveRecord::Base.connection.execute("CREATE TABLE IF NOT EXISTS `test_users` (`id` int(11) NOT NULL AUTO_INCREMENT, `name` varchar(255) NOT NULL, PRIMARY KEY (`id`)) DEFAULT CHARSET=utf8;")
+    ActiveRecord::Base.connection.execute(
+      "CREATE TABLE IF NOT EXISTS `test_users` (`id` int(11) NOT NULL AUTO_INCREMENT, " \
+      "`name` varchar(255) NOT NULL, `cart` blob, PRIMARY KEY (`id`)) DEFAULT CHARSET=utf8;"
+    )
   end
 
   config.before(:each) do


### PR DESCRIPTION
Using demoji we were seeing issues with data in one of the table's binary columns being double encoded - this should fix that. 