### PR TITLE
Update bundler requirement

### DIFF
--- a/demoji.gemspec
+++ b/demoji.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "activerecord"

--- a/spec/models/test_user_spec.rb
+++ b/spec/models/test_user_spec.rb
@@ -51,11 +51,19 @@ describe TestUser do
     expect(u.reload.name.strip).to eql "#{ord_to_str(252)}"
   end
 
-   it "doesn't remove valid 3-byte utf8 chars" do
+  it "doesn't remove valid 3-byte utf8 chars" do
     u = TestUser.new
-    u.name = "#{ord_to_str(10004)} #{ord_to_str(10027)} #{ord_to_str(66318)} abc"
+    u.name = "#{ord_to_str(10004)} #{ord_to_str(10027)} \xE2\x9C\x8C\xEF\xB8\x8F #{ord_to_str(66318)} abc"
     expect { u.save }.to_not raise_error
     expect(u).to be_persisted
-    expect(u.reload.name.strip).to eql "#{ord_to_str(10004)} #{ord_to_str(10027)}   abc"
+    expect(u.reload.name.strip).to eql "#{ord_to_str(10004)} #{ord_to_str(10027)} \xE2\x9C\x8C\xEF\xB8\x8F   abc"
+  end
+
+  it "removes emoji modifier chars" do
+    u = TestUser.new
+    u.name = "#{ord_to_str(10004)} #{ord_to_str(10027)} \xE2\x9C\x8C\xF0\x9F\x8F\xBE #{ord_to_str(66318)} abc"
+    expect { u.save }.to_not raise_error
+    expect(u).to be_persisted
+    expect(u.reload.name.strip).to eql "#{ord_to_str(10004)} #{ord_to_str(10027)} #{ord_to_str(9996)}    abc"
   end
 end

--- a/spec/models/test_user_spec.rb
+++ b/spec/models/test_user_spec.rb
@@ -58,12 +58,4 @@ describe TestUser do
     expect(u).to be_persisted
     expect(u.reload.name.strip).to eql "#{ord_to_str(10004)} #{ord_to_str(10027)}   abc"
   end
-
-   it "doesn't remove valid 4-byte utf8 chars" do
-    u = TestUser.new
-    u.name = "#{ord_to_str(10004)} #{ord_to_str(10027)} #{ord_to_str(131083)} abc"
-    expect { u.save }.to_not raise_error
-    expect(u).to be_persisted
-    expect(u.reload.name.strip).to eql "#{ord_to_str(10004)} #{ord_to_str(10027)}   abc"
-  end
 end


### PR DESCRIPTION
Validate the characters are less than 4 bytes instead of checking codepoint range. Some emojis are represented by a 3 byte codepoint but include other info like color so they are actually larger than 3 bytes (✌️ , etc)
